### PR TITLE
[CORE] Add GetAllRentalsCommandHandler and Callback Handling for Rental Listings in Telegram Bot

### DIFF
--- a/src/main/java/com/carshare/rentalsystem/dto/rental/RentalPreviewResponseDto.java
+++ b/src/main/java/com/carshare/rentalsystem/dto/rental/RentalPreviewResponseDto.java
@@ -1,0 +1,12 @@
+package com.carshare.rentalsystem.dto.rental;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class RentalPreviewResponseDto {
+    private Long id;
+    private boolean active;
+    private Long userId;
+}

--- a/src/main/java/com/carshare/rentalsystem/mapper/RentalMapper.java
+++ b/src/main/java/com/carshare/rentalsystem/mapper/RentalMapper.java
@@ -2,6 +2,7 @@ package com.carshare.rentalsystem.mapper;
 
 import com.carshare.rentalsystem.config.MapperConfig;
 import com.carshare.rentalsystem.dto.rental.CreateRentalRequestDto;
+import com.carshare.rentalsystem.dto.rental.RentalPreviewResponseDto;
 import com.carshare.rentalsystem.dto.rental.RentalResponseDto;
 import com.carshare.rentalsystem.model.Rental;
 import org.mapstruct.Mapper;
@@ -20,4 +21,13 @@ public interface RentalMapper {
 
     @Mapping(target = "car", source = "carId", qualifiedByName = "carById")
     Rental toEntity(CreateRentalRequestDto requestDto);
+
+    @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "active", source = "rental", qualifiedByName = "isRentalActive")
+    RentalPreviewResponseDto toPreviewDto(Rental rental);
+
+    @Named("isRentalActive")
+    default boolean isRentalActive(Rental rental) {
+        return rental.getActualReturnDate() == null;
+    }
 }

--- a/src/main/java/com/carshare/rentalsystem/repository/rental/RentalRepository.java
+++ b/src/main/java/com/carshare/rentalsystem/repository/rental/RentalRepository.java
@@ -17,6 +17,13 @@ public interface RentalRepository extends JpaRepository<Rental, Long>,
             + " WHERE r.user.id = :userId")
     Page<Rental> findAllByUserIdWithCarAndUser(@Param("userId") Long userId, Pageable pageable);
 
+    @Query("SELECT r FROM Rental r JOIN FETCH r.user"
+            + " WHERE r.user.id = :userId")
+    Page<Rental> findAllByUserIdWithUser(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("SELECT r FROM Rental r JOIN FETCH r.user")
+    Page<Rental> findAllWithUser(Pageable pageable);
+
     @Query("SELECT r FROM Rental r JOIN FETCH r.car c JOIN FETCH r.user u WHERE r.id = :rentalId")
     Optional<Rental> findByIdWithCarAndUser(@Param("rentalId") Long rentalId);
 

--- a/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/TelegramBotService.java
+++ b/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/TelegramBotService.java
@@ -4,9 +4,11 @@ import com.carshare.rentalsystem.model.TelegramUserLink;
 import com.carshare.rentalsystem.repository.telegram.user.link.TelegramUserLinkRepository;
 import com.carshare.rentalsystem.service.notifications.telegram.command.handler.TelegramCommandDispatcher;
 import com.carshare.rentalsystem.service.notifications.telegram.command.handler.TelegramCommandHandler;
+import com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.callback.handler.AllRentalsCallbackHandler;
 import com.carshare.rentalsystem.service.notifications.telegram.templates.NotificationRecipient;
 import com.pengrad.telegrambot.TelegramBot;
 import com.pengrad.telegrambot.UpdatesListener;
+import com.pengrad.telegrambot.model.CallbackQuery;
 import com.pengrad.telegrambot.model.Message;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
@@ -21,6 +23,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class TelegramBotService {
     public static final String MANAGER_ROLE = "MANAGER";
+    public static final String CUSTOMER_ROLE = "CUSTOMER";
 
     private static final String COMMAND_PREFIX = "/";
     private static final String SPACE_DELIMITER = " ";
@@ -34,6 +37,7 @@ public class TelegramBotService {
     private final TelegramUserLinkRepository telegramUserLinkRepository;
     private final TelegramCommandDispatcher telegramCommandDispatcher;
     private final ActiveTelegramUserStorage activeUserLinks;
+    private final AllRentalsCallbackHandler allRentalsCallbackHandler;
 
     @PostConstruct
     public void init() {
@@ -45,6 +49,9 @@ public class TelegramBotService {
             for (Update update : updates) {
                 if (update.message() != null) {
                     handleMessage(update.message());
+                } else if (update.callbackQuery() != null) {
+                    CallbackQuery callbackQuery = update.callbackQuery();
+                    allRentalsCallbackHandler.handleCallback(this.bot, callbackQuery);
                 }
             }
             return UpdatesListener.CONFIRMED_UPDATES_ALL;

--- a/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/command/handler/rental/command/GetAllRentalsCommandHandler.java
+++ b/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/command/handler/rental/command/GetAllRentalsCommandHandler.java
@@ -1,0 +1,99 @@
+package com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command;
+
+import static com.carshare.rentalsystem.service.notifications.telegram.TelegramBotService.CUSTOMER_ROLE;
+
+import com.carshare.rentalsystem.dto.rental.RentalPreviewResponseDto;
+import com.carshare.rentalsystem.model.TelegramUserLink;
+import com.carshare.rentalsystem.service.notifications.telegram.ActiveTelegramUserStorage;
+import com.carshare.rentalsystem.service.notifications.telegram.command.handler.TelegramCommandHandler;
+import com.carshare.rentalsystem.service.notifications.telegram.templates.RentalNotificationTemplates;
+import com.carshare.rentalsystem.service.rental.RentalService;
+import com.pengrad.telegrambot.TelegramBot;
+import com.pengrad.telegrambot.model.Message;
+import com.pengrad.telegrambot.model.request.InlineKeyboardButton;
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup;
+import com.pengrad.telegrambot.request.SendMessage;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class GetAllRentalsCommandHandler implements TelegramCommandHandler {
+    public static final String GET_ALL_RENTALS_COMMAND = "/get_all_rentals";
+    public static final int PAGE_SIZE = 5;
+    public static final String PREVIOUS_BUTTON_TEXT = "⬅️ Previous";
+    public static final String NEXT_BUTTON_TEXT = "➡️ Next";
+    public static final String RENTALS_PAGE_CALLBACK_PREFIX = "rentals_page:";
+    public static final int PAGE_INDEX_OFFSET = 1;
+    public static final int FIRST_PAGE_INDEX = 1;
+    public static final int NUMBER_OF_ROWS = 1;
+    public static final int FIRST_ROW_INDEX = 0;
+    public static final int EMPTY_ARRAY_SIZE = 0;
+
+    private final RentalService rentalService;
+    private final ActiveTelegramUserStorage telegramUserStorage;
+    private final RentalNotificationTemplates rentalNotificationTemplates;
+
+    @Override
+    public String getCommand() {
+        return GET_ALL_RENTALS_COMMAND;
+    }
+
+    @Override
+    public void handle(TelegramBot bot, Message message) {
+        Long chatId = message.chat().id();
+        TelegramUserLink telegramUserLink = telegramUserStorage.findByChatId(chatId).orElse(null);
+
+        if (telegramUserLink == null) {
+            bot.execute(new SendMessage(chatId, "❗ You are not linked."));
+            return;
+        }
+
+        boolean isCustomer = telegramUserLink.getUser().getRole()
+                .getRole().name().equals(CUSTOMER_ROLE);
+
+        int pageNumber = 0;
+        Page<RentalPreviewResponseDto> page = rentalService.getAllRentalsPreview(
+                isCustomer,
+                telegramUserLink.getUserId(),
+                PageRequest.of(pageNumber, PAGE_SIZE)
+        );
+
+        String response = rentalNotificationTemplates.createRentalListPageMessage(isCustomer, page);
+
+        SendMessage sendMessage = new SendMessage(chatId, response);
+        sendMessage.replyMarkup(createPaginationButtons(
+                page.getNumber() + PAGE_INDEX_OFFSET, page.getTotalPages()));
+
+        bot.execute(sendMessage);
+    }
+
+    private InlineKeyboardMarkup createPaginationButtons(int currentPage, int totalPages) {
+        List<InlineKeyboardButton> buttons = new ArrayList<>();
+
+        if (currentPage > FIRST_PAGE_INDEX) {
+            buttons.add(new InlineKeyboardButton(PREVIOUS_BUTTON_TEXT)
+                    .callbackData(
+                            RENTALS_PAGE_CALLBACK_PREFIX + (currentPage - PAGE_INDEX_OFFSET)
+                    )
+            );
+        }
+
+        if (currentPage < totalPages) {
+            buttons.add(new InlineKeyboardButton(NEXT_BUTTON_TEXT)
+                    .callbackData(RENTALS_PAGE_CALLBACK_PREFIX + (currentPage + PAGE_INDEX_OFFSET)
+                    )
+            );
+        }
+
+        InlineKeyboardButton[][] keyboard =
+                new InlineKeyboardButton[NUMBER_OF_ROWS][buttons.size()];
+        keyboard[FIRST_ROW_INDEX] = buttons.toArray(new InlineKeyboardButton[EMPTY_ARRAY_SIZE]);
+
+        return new InlineKeyboardMarkup(keyboard);
+    }
+}

--- a/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/command/handler/rental/command/GetRentalCommandHandler.java
+++ b/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/command/handler/rental/command/GetRentalCommandHandler.java
@@ -1,4 +1,4 @@
-package com.carshare.rentalsystem.service.notifications.telegram.command.handler;
+package com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command;
 
 import static com.carshare.rentalsystem.service.notifications.telegram.TelegramBotService.MANAGER_ROLE;
 
@@ -6,6 +6,7 @@ import com.carshare.rentalsystem.dto.rental.RentalResponseDto;
 import com.carshare.rentalsystem.exception.EntityNotFoundException;
 import com.carshare.rentalsystem.model.TelegramUserLink;
 import com.carshare.rentalsystem.service.notifications.telegram.ActiveTelegramUserStorage;
+import com.carshare.rentalsystem.service.notifications.telegram.command.handler.TelegramCommandHandler;
 import com.carshare.rentalsystem.service.notifications.telegram.templates.RentalNotificationTemplates;
 import com.carshare.rentalsystem.service.rental.RentalService;
 import com.pengrad.telegrambot.TelegramBot;
@@ -55,7 +56,10 @@ public class GetRentalCommandHandler implements TelegramCommandHandler {
         try {
             Long rentalId = Long.parseLong(parts[RENTAL_ID_INDEX]);
 
-            if (telegramUserLink.getUser().getRole().getRole().name().equals(MANAGER_ROLE)) {
+            boolean isManager = telegramUserLink.getUser().getRole()
+                    .getRole().name().equals(MANAGER_ROLE);
+
+            if (isManager) {
                 RentalResponseDto responseDto = rentalService.getAnyRentalInfo(rentalId);
                 String responseMessage = rentalNotificationTemplates
                         .createGetRentalResponseMessage(

--- a/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/command/handler/rental/command/callback/handler/AllRentalsCallbackHandler.java
+++ b/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/command/handler/rental/command/callback/handler/AllRentalsCallbackHandler.java
@@ -1,0 +1,106 @@
+package com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.callback.handler;
+
+import static com.carshare.rentalsystem.service.notifications.telegram.TelegramBotService.CUSTOMER_ROLE;
+import static com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler.EMPTY_ARRAY_SIZE;
+import static com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler.FIRST_PAGE_INDEX;
+import static com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler.FIRST_ROW_INDEX;
+import static com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler.NEXT_BUTTON_TEXT;
+import static com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler.NUMBER_OF_ROWS;
+import static com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler.PAGE_INDEX_OFFSET;
+import static com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler.PREVIOUS_BUTTON_TEXT;
+import static com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler.RENTALS_PAGE_CALLBACK_PREFIX;
+
+import com.carshare.rentalsystem.dto.rental.RentalPreviewResponseDto;
+import com.carshare.rentalsystem.model.TelegramUserLink;
+import com.carshare.rentalsystem.service.notifications.telegram.ActiveTelegramUserStorage;
+import com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler;
+import com.carshare.rentalsystem.service.notifications.telegram.templates.RentalNotificationTemplates;
+import com.carshare.rentalsystem.service.rental.RentalService;
+import com.pengrad.telegrambot.TelegramBot;
+import com.pengrad.telegrambot.model.CallbackQuery;
+import com.pengrad.telegrambot.model.request.InlineKeyboardButton;
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup;
+import com.pengrad.telegrambot.request.EditMessageText;
+import com.pengrad.telegrambot.request.SendMessage;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AllRentalsCallbackHandler {
+    private static final String PAGE_SPLIT_DELIMITER = ":";
+    private static final int PAGE_NUMBER_PART = 1;
+
+    private final RentalService rentalService;
+    private final ActiveTelegramUserStorage telegramUserStorage;
+    private final RentalNotificationTemplates rentalNotificationTemplates;
+
+    public void handleCallback(TelegramBot bot, CallbackQuery callbackQuery) {
+        Long chatId = callbackQuery.message().chat().id();
+        String callbackData = callbackQuery.data();
+
+        TelegramUserLink telegramUserLink = telegramUserStorage.findByChatId(chatId).orElse(null);
+
+        if (telegramUserLink == null) {
+            bot.execute(new SendMessage(chatId, "❗ You are not linked."));
+            return;
+        }
+
+        boolean isCustomer = telegramUserLink.getUser().getRole()
+                .getRole().name().equals(CUSTOMER_ROLE);
+
+        if (callbackData.startsWith(RENTALS_PAGE_CALLBACK_PREFIX)) {
+            int pageNumber = Integer.parseInt(
+                    callbackData
+                            .split(PAGE_SPLIT_DELIMITER)[PAGE_NUMBER_PART]) - PAGE_INDEX_OFFSET;
+
+            Page<RentalPreviewResponseDto> page = rentalService.getAllRentalsPreview(
+                    isCustomer,
+                    telegramUserLink.getUserId(),
+                    PageRequest.of(pageNumber, GetAllRentalsCommandHandler.PAGE_SIZE)
+            );
+
+            String response = rentalNotificationTemplates.createRentalListPageMessage(
+                    isCustomer, page);
+
+            InlineKeyboardMarkup keyboardMarkup = createPaginationButtons(
+                    page.getNumber() + PAGE_INDEX_OFFSET, page.getTotalPages());
+
+            EditMessageText editMessage = new EditMessageText(chatId,
+                    callbackQuery.message().messageId(), response);
+            editMessage.replyMarkup(keyboardMarkup);
+
+            bot.execute(editMessage);
+        }
+    }
+
+    private InlineKeyboardMarkup createPaginationButtons(int currentPage, int totalPages) {
+        List<InlineKeyboardButton> buttons = new ArrayList<>();
+
+        if (currentPage > FIRST_PAGE_INDEX) {
+            buttons.add(new InlineKeyboardButton(PREVIOUS_BUTTON_TEXT)
+                    .callbackData(
+                            RENTALS_PAGE_CALLBACK_PREFIX + (currentPage - PAGE_INDEX_OFFSET)
+                    )
+            );
+        }
+
+        if (currentPage < totalPages) {
+            buttons.add(new InlineKeyboardButton(NEXT_BUTTON_TEXT)
+                    .callbackData(
+                            RENTALS_PAGE_CALLBACK_PREFIX + (currentPage + PAGE_INDEX_OFFSET)
+                    )
+            );
+        }
+
+        InlineKeyboardButton[][] keyboard =
+                new InlineKeyboardButton[NUMBER_OF_ROWS][buttons.size()];
+        keyboard[FIRST_ROW_INDEX] = buttons.toArray(new InlineKeyboardButton[EMPTY_ARRAY_SIZE]);
+
+        return new InlineKeyboardMarkup(keyboard);
+    }
+}

--- a/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/templates/RentalNotificationTemplates.java
+++ b/src/main/java/com/carshare/rentalsystem/service/notifications/telegram/templates/RentalNotificationTemplates.java
@@ -1,6 +1,9 @@
 package com.carshare.rentalsystem.service.notifications.telegram.templates;
 
+import static com.carshare.rentalsystem.service.notifications.telegram.command.handler.rental.command.GetAllRentalsCommandHandler.PAGE_INDEX_OFFSET;
+
 import com.carshare.rentalsystem.dto.car.CarPreviewResponseDto;
+import com.carshare.rentalsystem.dto.rental.RentalPreviewResponseDto;
 import com.carshare.rentalsystem.dto.rental.RentalResponseDto;
 import com.carshare.rentalsystem.model.Car;
 import com.carshare.rentalsystem.model.Rental;
@@ -9,6 +12,7 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.EnumMap;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -194,6 +198,31 @@ public class RentalNotificationTemplates {
                     rentalStatus
             );
         }
+    }
+
+    public String createRentalListPageMessage(boolean isCustomer,
+                                              Page<RentalPreviewResponseDto> page) {
+        StringBuilder builder = new StringBuilder();
+        int currentPage = page.getNumber() + PAGE_INDEX_OFFSET;
+        int totalPages = page.getTotalPages();
+
+        builder.append(String.format("📋 Rentals — page %d of %d:\n\n", currentPage, totalPages));
+
+        for (RentalPreviewResponseDto rental : page.getContent()) {
+            builder.append("🔹 Rental ID: ")
+                    .append(rental.getId())
+                    .append(" — ")
+                    .append(rental.isActive() ? "▶ Active" : "✅ Completed");
+
+            if (!isCustomer) {
+                builder.append(" — 👤 User ID: ").append(rental.getUserId());
+            }
+
+            builder.append("\n");
+        }
+
+        builder.append("\n📎 To view details: /get_rental <rental_id>");
+        return builder.toString();
     }
 
     private String formatUserInfo(User user) {

--- a/src/main/java/com/carshare/rentalsystem/service/rental/RentalService.java
+++ b/src/main/java/com/carshare/rentalsystem/service/rental/RentalService.java
@@ -1,6 +1,7 @@
 package com.carshare.rentalsystem.service.rental;
 
 import com.carshare.rentalsystem.dto.rental.CreateRentalRequestDto;
+import com.carshare.rentalsystem.dto.rental.RentalPreviewResponseDto;
 import com.carshare.rentalsystem.dto.rental.RentalResponseDto;
 import com.carshare.rentalsystem.dto.rental.RentalSearchParameters;
 import org.springframework.data.domain.Page;
@@ -15,6 +16,9 @@ public interface RentalService {
 
     Page<RentalResponseDto> getSpecificRentals(RentalSearchParameters params,
                                                Pageable pageable);
+
+    Page<RentalPreviewResponseDto> getAllRentalsPreview(boolean isManager, Long userId,
+                                                        Pageable pageable);
 
     RentalResponseDto getAnyRentalInfo(Long rentalId);
 

--- a/src/main/java/com/carshare/rentalsystem/service/rental/RentalServiceImpl.java
+++ b/src/main/java/com/carshare/rentalsystem/service/rental/RentalServiceImpl.java
@@ -1,6 +1,7 @@
 package com.carshare.rentalsystem.service.rental;
 
 import com.carshare.rentalsystem.dto.rental.CreateRentalRequestDto;
+import com.carshare.rentalsystem.dto.rental.RentalPreviewResponseDto;
 import com.carshare.rentalsystem.dto.rental.RentalResponseDto;
 import com.carshare.rentalsystem.dto.rental.RentalSearchParameters;
 import com.carshare.rentalsystem.dto.rental.event.dto.RentalCreatedEventDto;
@@ -86,6 +87,17 @@ public class RentalServiceImpl implements RentalService {
 
         return rentalRepository.findAll(rentalSpecification, pageable)
                 .map(rentalMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<RentalPreviewResponseDto> getAllRentalsPreview(boolean isManager,
+                                                               Long userId, Pageable pageable) {
+        Page<Rental> rentals = isManager
+                ? rentalRepository.findAllWithUser(pageable)
+                : rentalRepository.findAllByUserIdWithUser(userId, pageable);
+
+        return rentals.map(rentalMapper::toPreviewDto);
     }
 
     @Override


### PR DESCRIPTION
### New features:
- Created `RentalPreviewResponseDto`, which is used in messages sent to the Telegram chat.
- Added `toPreviewDto()` method in the `RentalMapper`.
- Introduced two new methods in the `RentalRepository`: `findAllByUserIdWithUser()` and `findAllWithUser()`, which return paginated rental listings with associated users.
- Developed `getAllRentalsPreview()` in the `RentalService` to return a paginated list of `Page<RentalPreviewResponseDto>`.
- Implemented `createRentalListPageMessage()` method in `RentalNotificationTemplates` for generating rental list messages.
- Created `GetAllRentalsCommandHandler` to handle the command that returns a paginated rental list (`Page<RentalPreviewResponseDto>`) to the user in the Telegram chat. Customers see only their own rentals, while managers see all rentals.
- Developed `AllRentalsCallbackHandler` to allow users to "scroll" through rental listings in the chat using convenient inline buttons (pagination).
- Added `callbackQuery()` handling in the `init()` method of `TelegramBotService`. Currently, `AllRentalsCallbackHandler` is **hardcoded**, but a `TelegramCallbackDispatcher` will be **implemented in the future** to automatically determine the appropriate handler, improving flexibility and scalability.